### PR TITLE
Fix: the paths of the dependent files

### DIFF
--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -26,7 +26,7 @@ all: libsha3sml
 
 
 .PHONY: libsha3sml-nodoc
-libsha3sml-nodoc: src/sources.mlb $(TYPECHECK_DUMMY)
+libsha3sml-nodoc: $(TYPECHECK_DUMMY)
 
 
 .PHONY: libsha3sml
@@ -53,6 +53,13 @@ endif
 libsha3sml.mlb.d: libsha3sml.mlb
 	@echo "  [GEN] $@"
 	@$(SHELL) -ec '$(MLTON) '"$(MLTON_FLAGS)"' -stop f $< \
+		| while read file; do \
+		    if expr $$(readlink -f $$file) : ^$$(pwd) >/dev/null; then \
+		      echo "$$(realpath --relative-to=$$(pwd) $$file)" ; \
+		    else \
+		      echo $$file; \
+		    fi; \
+		  done \
 		| sed -e "1i$(TYPECHECK_DUMMY) $@:\\\\" -e "s|.*|  & \\\\|" -e "\$$s| \\\\||" > $@; \
 		[ -s $@ ] || rm -rf $@'
 
@@ -60,6 +67,13 @@ libsha3sml.mlb.d: libsha3sml.mlb
 %.mlb.d: %.mlb
 	@echo "  [GEN] $@"
 	@$(SHELL) -ec '$(MLTON) '"$(MLTON_FLAGS)"' -stop f $< \
+		| while read file; do \
+		    if expr $$(readlink -f $$file) : ^$$(pwd) >/dev/null; then \
+		      echo "$$(realpath --relative-to=$$(pwd) $$file)" ; \
+		    else \
+		      echo $$file; \
+		    fi; \
+		  done \
 		| sed -e "1i$(<:.mlb=) $@:\\\\" -e "s|.*|  & \\\\|" -e "\$$s| \\\\||" > $@; \
 		[ -s $@ ] || rm -rf $@'
 


### PR DESCRIPTION
Change absolute path to relative paths to match dependency rules of the Makefile.mlton.
e.g., /path/to/sha3_sml/src/sources.mlb to src/sources.mlb .